### PR TITLE
Drop vestigial CNAME (GitHub Pages disabled)

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-finnoybu.com


### PR DESCRIPTION
GitHub Pages has been disabled on this repo and finnoybu.com's apex now serves from Cloudflare Pages. The root `CNAME` file was a GitHub Pages config artifact and is no longer used.

🤖 Generated with [Claude Code](https://claude.com/claude-code)