### PR TITLE
Use finnoybu-com D1 + add reading-data schema (retire finnoybu-trilogy)

### DIFF
--- a/migrations/0001_reading_data.sql
+++ b/migrations/0001_reading_data.sql
@@ -1,0 +1,73 @@
+-- Reading-data tables for the `finnoybu-com` D1.
+-- Mirrors finnoybu-trilogy/src/db/schema.ts so fiction.finnoybu.com and
+-- memoirs.finnoybu.com can rebind to this D1 in place of the legacy
+-- `finnoybu-trilogy` D1 without their app code changing. Tables are FK-linked
+-- to `user.id` (created in 0000_init.sql) so deleting a user cascades.
+
+-- Reading progress — one row per (user, chapter). Synced from localStorage
+-- for logged-in users so they can resume across devices.
+CREATE TABLE reading_progress (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  chapter_slug TEXT NOT NULL,
+  scroll_position REAL NOT NULL DEFAULT 0,
+  percent REAL NOT NULL DEFAULT 0,
+  last_read_at INTEGER NOT NULL
+);
+CREATE UNIQUE INDEX reading_progress_user_chapter_uniq
+  ON reading_progress (user_id, chapter_slug);
+CREATE INDEX reading_progress_user_idx ON reading_progress (user_id);
+
+-- Bookmarks — saved positions inside a chapter. Multi-bookmark per chapter.
+CREATE TABLE bookmarks (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  chapter_slug TEXT NOT NULL,
+  scroll_position REAL NOT NULL,
+  selection_start INTEGER,
+  label TEXT,
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX bookmarks_user_idx ON bookmarks (user_id);
+CREATE INDEX bookmarks_user_chapter_idx ON bookmarks (user_id, chapter_slug);
+
+-- Annotations — personal notes on a text selection.
+CREATE TABLE annotations (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  chapter_slug TEXT NOT NULL,
+  text_selection TEXT NOT NULL,
+  note TEXT NOT NULL DEFAULT '',
+  selection_start INTEGER,
+  selection_end INTEGER,
+  created_at INTEGER NOT NULL,
+  updated_at INTEGER NOT NULL
+);
+CREATE INDEX annotations_user_idx ON annotations (user_id);
+CREATE INDEX annotations_user_chapter_idx ON annotations (user_id, chapter_slug);
+
+-- Errata reports — readers flagging typos / factual issues / etc.
+CREATE TABLE errata_reports (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  chapter_slug TEXT NOT NULL,
+  text_selection TEXT NOT NULL,
+  description TEXT NOT NULL,
+  status TEXT NOT NULL DEFAULT 'pending',
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX errata_user_idx ON errata_reports (user_id);
+
+-- Purchases — Stripe-backed digital downloads. `product_id` is the catalog
+-- slug (e.g. `salt-and-silence`, `reminiscences`).
+CREATE TABLE purchases (
+  id TEXT PRIMARY KEY NOT NULL,
+  user_id TEXT NOT NULL REFERENCES user(id) ON DELETE CASCADE,
+  product_id TEXT NOT NULL,
+  stripe_session_id TEXT NOT NULL UNIQUE,
+  amount_cents INTEGER NOT NULL,
+  currency TEXT NOT NULL DEFAULT 'usd',
+  created_at INTEGER NOT NULL
+);
+CREATE INDEX purchases_user_idx ON purchases (user_id);
+CREATE INDEX purchases_user_product_idx ON purchases (user_id, product_id);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,11 +1,14 @@
-// Drizzle schema — auth tables only. This is the central auth host;
-// fiction.finnoybu.com and memoirs.finnoybu.com bind the same D1 and own
-// the reading-data tables (reading_progress / bookmarks / annotations /
-// errata_reports / purchases) authored in the finnoybu-trilogy repo.
+// Drizzle schema — auth tables for the central Better Auth handler.
+// Lives in the `finnoybu-com` D1, which is the single source of truth for
+// the *.finnoybu.com family (replacing the legacy `finnoybu-trilogy` D1).
+// The reading-data tables (reading_progress / bookmarks / annotations /
+// errata_reports / purchases) live in the same D1 and are authored in the
+// finnoybu-trilogy repo; this schema file types only the four auth tables
+// the central handler needs.
 //
-// One user row spans all three sites because cookies are set at
-// `.finnoybu.com`. The Better Auth catch-all on finnoybu.com writes to the
-// tables below; everything else reads via the shared cookie.
+// Cookies are scoped to `.finnoybu.com` so one user row spans all three
+// sites; fiction and memoirs read the cookie + look up the session in this
+// same D1.
 
 import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core';
 

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -5,11 +5,17 @@
 # Cloudflare Pages dashboard:
 #   Pages → finnoybu-com → Settings → Variables and Secrets
 #
-# D1 is *shared* with fiction.finnoybu.com and memoirs.finnoybu.com (same
-# database_id). One user row spans all three sites because cookies are set
-# at `.finnoybu.com`. The auth tables (user/session/account/verification) are
-# written by the central handler that lives here; fiction/memoirs hold the
-# reading-data tables in the same D1.
+# D1 `finnoybu-com` (uuid b84a5d8b-c080-4d7e-b9f8-c83af3ed6304) is the central
+# database for the *.finnoybu.com family. The auth tables
+# (user/session/account/verification) are written by the central handler that
+# lives here; the reading-data tables (reading_progress / bookmarks /
+# annotations / errata_reports / purchases) live in the same D1 and are owned
+# by fiction.finnoybu.com and memoirs.finnoybu.com (schema authored in the
+# finnoybu-trilogy repo). Cookies are scoped to `.finnoybu.com` so one user
+# row spans all three sites.
+#
+# This DB replaces the legacy `finnoybu-trilogy` D1, which is being retired
+# once fiction + memoirs rebind to finnoybu-com.
 #
 # OAuth Client IDs are public per provider docs — they get embedded in OAuth
 # redirect URLs anyway. AWS access keys are treated as a credential pair, so
@@ -31,8 +37,8 @@ pages_build_output_dir = "./dist"
 
 [[d1_databases]]
 binding = "DB"
-database_name = "finnoybu-trilogy"
-database_id = "954d7506-aea2-4900-8f84-07f227466e59"
+database_name = "finnoybu-com"
+database_id = "b84a5d8b-c080-4d7e-b9f8-c83af3ed6304"
 
 [vars]
 AWS_REGION = "us-east-1"
@@ -44,8 +50,8 @@ EMAIL_FROM = "Finnoybu.com <hello@finnoybu.com>"
 
 [[env.production.d1_databases]]
 binding = "DB"
-database_name = "finnoybu-trilogy"
-database_id = "954d7506-aea2-4900-8f84-07f227466e59"
+database_name = "finnoybu-com"
+database_id = "b84a5d8b-c080-4d7e-b9f8-c83af3ed6304"
 
 [env.production.vars]
 PUBLIC_SITE_URL = "https://finnoybu.com"
@@ -63,8 +69,8 @@ GOOGLE_CLIENT_ID = "753668982308-i3cvsardb34qcgkqau174uskn4aoqkn5.apps.googleuse
 
 [[env.preview.d1_databases]]
 binding = "DB"
-database_name = "finnoybu-trilogy"
-database_id = "954d7506-aea2-4900-8f84-07f227466e59"
+database_name = "finnoybu-com"
+database_id = "b84a5d8b-c080-4d7e-b9f8-c83af3ed6304"
 
 [env.preview.vars]
 PUBLIC_SITE_URL = ""


### PR DESCRIPTION
Switches finnoybu.com's wrangler.toml to bind the dedicated `finnoybu-com` D1 (uuid `b84a5d8b-…`) instead of the legacy `finnoybu-trilogy` D1.

Adds `migrations/0001_reading_data.sql` — the reading-data schema (reading_progress / bookmarks / annotations / errata_reports / purchases) — so fiction and memoirs can rebind to this D1 next without their app code changing. Migration already applied to the remote D1.

Once fiction + memoirs switch, `finnoybu-trilogy` D1 can be deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)