### PR TITLE
Apple form_post CSRF fix: state cookie SameSite=None

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -212,6 +212,21 @@ export function createAuth({
               sameSite: 'lax' as const,
               secure: true,
             },
+            // Apple's Sign In uses response_mode=form_post — Apple POSTs back
+            // from appleid.apple.com cross-site to our callback. SameSite=Lax
+            // strips the state cookie on that POST, which makes Better Auth's
+            // CSRF middleware reject the request as a cross-site form
+            // submission. SameSite=None lets the state cookie survive; the
+            // actual CSRF protection comes from the random state value being
+            // compared against the cookie's encrypted contents, not from
+            // SameSite. Session cookie stays SameSite=Lax (the default).
+            cookies: {
+              state: {
+                attributes: {
+                  sameSite: 'none' as const,
+                },
+              },
+            },
           },
         }
       : {}),


### PR DESCRIPTION
## Problem

Apple Sign In uses `response_mode=form_post` — appleid.apple.com POSTs the OAuth result cross-site to `/api/auth/callback/apple`. SameSite=Lax cookies are stripped on cross-site POSTs (per spec), so Better Auth saw the callback as a CSRF attack (`Sec-Fetch-Site: cross-site` + cookies missing = its block signature). Result: every Apple sign-in attempt returned "Cross-site POST form submissions are forbidden."

Centralizing auth on finnoybu.com (Phase 1) didn't fix this — the POST is still cross-site to finnoybu.com regardless of where session cookies are scoped. This was a wrong assumption baked into the project early on. Memory leaf [[better-auth-apple-form-post-csrf]] was updated yesterday with the correction.

## Diagnosis

Reading [origin-check.mjs:129](node_modules/better-auth/dist/api/middlewares/origin-check.mjs):

```js
if (headers.has("cookie")) return await validateOrigin(ctx);
```

`validateFormCsrf` only enforces the Sec-Fetch CSRF check when **no cookies** are present. If any cookie is on the request, it falls through to origin validation. Our auth.ts already includes `https://appleid.apple.com` in `trustedOrigins`, so `validateOrigin` passes for Apple's callback POST. The state cookie's encrypted contents are then matched against the state URL param (state.mjs `parseGenericState`) — that's the real CSRF defense.

So the fix is just to keep the state cookie alive across Apple's cross-site POST.

## Fix

Better Auth 1.6.11 exposes per-cookie attribute overrides via `advanced.cookies.<name>.attributes` ([cookies/index.mjs:27-39](node_modules/better-auth/dist/cookies/index.mjs)) — these apply LAST and override all defaults.

Setting `state` cookie's `sameSite: 'none'` makes it travel cross-site. Session cookie and all others stay SameSite=Lax (the default in our `defaultCookieAttributes`).

## What this does NOT change

- Session cookie SameSite — still Lax (good security for the actual session)
- Trusted origins list — unchanged
- CSRF protection for any other endpoint — unaffected
- Other OAuth providers (Google/Facebook/GitHub) — they use `response_mode=query` (302 GET callback) so SameSite=Lax cookies travel fine; no change in their flow

## Test plan

After merge + deploy:
- [ ] `https://finnoybu.com/sign-in` → click "Sign in with Apple" → completes successfully
- [ ] Regression: Google, Facebook, email/password still work
- [ ] `__Secure-better-auth.state` cookie inspected in DevTools: `SameSite=None; Secure`
- [ ] `__Secure-better-auth.session_token` cookie: still `SameSite=Lax`

🤖 Generated with [Claude Code](https://claude.com/claude-code)