### PR TITLE
Disable Astro security.checkOrigin so Apple OAuth callback POST goes through

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -17,6 +17,18 @@ export default defineConfig({
   build: {
     format: 'directory',
   },
+  // Disable Astro's blanket cross-origin POST block. Sign in with Apple uses
+  // response_mode=form_post — appleid.apple.com cross-site POSTs the OAuth
+  // result to /api/auth/callback/apple. Astro 5's security.checkOrigin
+  // (default true) intercepts that with a 403 before our handler runs, even
+  // though it's the legitimate OAuth callback. The only routes that accept
+  // POST on this site are under /api/auth/*, which is Better Auth — and
+  // Better Auth runs its own CSRF defense (validateFormCsrf + trustedOrigins
+  // + signed state cookie matched against the OAuth state param), so we
+  // aren't losing CSRF protection by turning Astro's blanket guard off.
+  security: {
+    checkOrigin: false,
+  },
   integrations: [
     sitemap(),
     tailwind({ applyBaseStyles: false }),


### PR DESCRIPTION
## The real Apple CSRF culprit

The 403 "Cross-site POST form submissions are forbidden" on Apple's callback wasn't Better Auth's CSRF guard — it was **Astro 5's built-in `security.checkOrigin`** (default `true`). Astro's `createOriginCheckMiddleware` runs BEFORE user middleware via `unshift` (base-pipeline.js line 50-52), so Better Auth never even saw Apple's POST.

Verified by:
- Error string exact match in `node_modules/astro/dist/core/app/middlewares.js:22-24` — `\`Cross-site \${request.method} form submissions are forbidden\``
- Better Auth's equivalent error is the different `CROSS_SITE_NAVIGATION_LOGIN_BLOCKED` ("Cross-site navigation login blocked...") — not what we saw.
- Astro's check fires when `Origin` header doesn't match `url.origin` AND `Content-Type` is form-like. Apple's POST has `Origin: https://appleid.apple.com` and `Content-Type: application/x-www-form-urlencoded` → blocked.

## Fix

Set `security: { checkOrigin: false }` in `astro.config.mjs`.

## Risk assessment

The only POST-accepting routes in this project are under `/api/auth/*` (Better Auth catch-all). All other pages are static (`prerender = true`). Better Auth has its own multi-layered CSRF defense:
- `validateFormCsrf` middleware (origin-check.mjs:115)
- `trustedOrigins` allow-list (`appleid.apple.com` already listed)
- Signed state cookie matched against the OAuth `state` URL parameter (state.mjs `parseGenericState`)

So disabling Astro's blanket guard doesn't reduce real CSRF protection — it removes a wrong-layer block that Better Auth's own defense handles correctly for the only routes that need it.

## Pairs with the SameSite=None change

The prior PR set the state cookie to SameSite=None so it survives Apple's cross-site POST. That fix is still needed: once Astro stops blocking the POST, Better Auth's `validateFormCsrf` runs. It checks for ANY cookie on the request; if none present, it blocks via its own CSRF rule. With SameSite=None, the state cookie travels → `validateFormCsrf` falls through to `validateOrigin` → `appleid.apple.com` is trusted → passes.

## Test plan

After merge + deploy:
- [ ] `https://finnoybu.com/sign-in` → Sign in with Apple → completes successfully
- [ ] Regression: Google + Facebook + email/password still work
- [ ] No other POST routes on the site, but spot-check the homepage still loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)