### PR TITLE
Phase 2B+2C: SignInModal auto-fire + GitHub central app

### DIFF
--- a/src/pages/sign-in.astro
+++ b/src/pages/sign-in.astro
@@ -172,31 +172,53 @@ export const prerender = true;
         }
       }
 
-      signinBtns.forEach((btn) => {
-        btn.addEventListener('click', async () => {
-          const provider = btn.dataset.provider;
-          setBtnsDisabled(true);
-          setStatus('Starting ' + provider + ' OAuth…');
-          try {
-            const res = await fetch('/api/auth/sign-in/social', {
-              method: 'POST',
-              headers: { 'content-type': 'application/json' },
-              credentials: 'include',
-              body: JSON.stringify({ provider, callbackURL: '/sign-in' }),
-            });
-            const data = await res.json();
-            if (data && data.url) {
-              window.location.href = data.url;
-            } else {
-              setStatus('Sign-in failed (' + provider + '): ' + JSON.stringify(data));
-              setBtnsDisabled(false);
-            }
-          } catch (err) {
-            setStatus('Sign-in error (' + provider + '): ' + err.message);
+      // Shared OAuth starter — used by manual button clicks AND by the
+      // auto-fire path that fiction/memoirs use when they redirect users
+      // here for OAuth (since GitHub/Apple require single-callback registration
+      // on finnoybu.com, all OAuth runs through this page).
+      async function startOAuth(provider, callbackURL) {
+        setBtnsDisabled(true);
+        setStatus('Starting ' + provider + ' OAuth…');
+        try {
+          const res = await fetch('/api/auth/sign-in/social', {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            credentials: 'include',
+            body: JSON.stringify({ provider, callbackURL }),
+          });
+          const data = await res.json();
+          if (data && data.url) {
+            window.location.href = data.url;
+          } else {
+            setStatus('Sign-in failed (' + provider + '): ' + JSON.stringify(data));
             setBtnsDisabled(false);
           }
+        } catch (err) {
+          setStatus('Sign-in error (' + provider + '): ' + err.message);
+          setBtnsDisabled(false);
+        }
+      }
+
+      signinBtns.forEach((btn) => {
+        btn.addEventListener('click', () => {
+          startOAuth(btn.dataset.provider, '/sign-in');
         });
       });
+
+      // Auto-fire when caller passed `?provider=...&callbackURL=...` in the URL.
+      // Caller (fiction/memoirs AuthModal) only sends trusted callbackURLs;
+      // Better Auth additionally validates against trustedOrigins server-side
+      // and rejects anything not on the allow-list, so a hostile callbackURL
+      // can't trick the OAuth flow into landing the user on an attacker site.
+      (function maybeAutoFire() {
+        const params = new URLSearchParams(window.location.search);
+        const provider = params.get('provider');
+        if (!provider) return;
+        const callbackURL = params.get('callbackURL') || '/sign-in';
+        // Skip refreshSession's "Not signed in." flash before the redirect.
+        setStatus('Redirecting to ' + provider + '…');
+        startOAuth(provider, callbackURL);
+      })();
 
       signoutBtn.addEventListener('click', async () => {
         signoutBtn.disabled = true;

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -61,7 +61,7 @@ EMAIL_FROM = "Finnoybu.com <hello@finnoybu.com>"
 GOOGLE_CLIENT_ID = "753668982308-i3cvsardb34qcgkqau174uskn4aoqkn5.apps.googleusercontent.com"
 FACEBOOK_CLIENT_ID = "4365482573696462"
 APPLE_CLIENT_ID = "finnoybu-com"
-# GITHUB_CLIENT_ID = "<add after creating central OAuth App on github.com>"
+GITHUB_CLIENT_ID = "Ov23li4nADGWGLvpGzKO"
 
 ## ═══════════════════════════════════════════════════════════════════════════
 ## PREVIEW — per-deploy *.finnoybu-com.pages.dev hashes. PUBLIC_SITE_URL and
@@ -83,4 +83,4 @@ EMAIL_FROM = "Finnoybu.com <hello@finnoybu.com>"
 GOOGLE_CLIENT_ID = "753668982308-i3cvsardb34qcgkqau174uskn4aoqkn5.apps.googleusercontent.com"
 FACEBOOK_CLIENT_ID = "4365482573696462"
 APPLE_CLIENT_ID = "finnoybu-com"
-# GITHUB_CLIENT_ID = "<add after creating central OAuth App on github.com>"
+GITHUB_CLIENT_ID = "Ov23li4nADGWGLvpGzKO"


### PR DESCRIPTION
## Goal

Complete OAuth centralization. After this PR (+ companion PRs in fiction/memoirs), all four OAuth providers route through finnoybu.com regardless of which subdomain the user is on. Email/password and magic-link stay local on fiction/memoirs.

## Changes

- **src/pages/sign-in.astro** — auto-fire OAuth when `?provider=...&callbackURL=...` query params are present. Lets fiction/memoirs redirect users here for the OAuth round-trip. Better Auth's `trustedOrigins` server-side check rejects unknown callbackURLs.
- **wrangler.toml** — `GITHUB_CLIENT_ID = "Ov23li4nADGWGLvpGzKO"` (fiction's existing GitHub OAuth App, repurposed for the central finnoybu.com role).

## Ken's parallel work (required before merge)

- GitHub Console: change Authorization callback URL on the existing OAuth App `Ov23li4nADGWGLvpGzKO` from `https://fiction.finnoybu.com/api/auth/callback/github` to `https://finnoybu.com/api/auth/callback/github`. Optionally rename the app for clarity.
- CF Pages → finnoybu-com → Variables and Secrets: add `GITHUB_CLIENT_SECRET` (Production + Preview) — value is the same as in finnoybu-trilogy's CF dashboard.

## Deploy order

This PR ships **first**, then fiction + memoirs PRs (so the central /sign-in auto-fire AND GitHub creds are live before fiction/memoirs start redirecting OAuth here).

## Test plan

- [ ] `https://finnoybu.com/sign-in?provider=google&callbackURL=https://fiction.finnoybu.com/` auto-fires Google OAuth and lands on fiction signed in
- [ ] `https://finnoybu.com/sign-in` (no params) still shows the test buttons, manual click still works
- [ ] All 4 providers on finnoybu.com/sign-in still work end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)