### PR TITLE
Trilogy blurb: Book II is live too

### DIFF
--- a/src/data/projects.ts
+++ b/src/data/projects.ts
@@ -41,9 +41,9 @@ export const PROJECTS: Project[] = [
     monogram: 'FT',
     tag: 'Fiction',
     blurb:
-      'A Norse fantasy trilogy written as E. A. Westbo. Book I, Salt and Silence, is complete; Books II and III are drafted.',
+      'A Norse fantasy trilogy written as E. A. Westbo. Book I (Salt and Silence) and Book II (The Long Return) are complete; Book III is drafted.',
     details:
-      'The Finnoybu Trilogy is a three-book Norse fantasy series, written under the pen name E. A. Westbo. Book I, Salt and Silence, is complete and prepared for print; Books II and III are drafted.',
+      'The Finnoybu Trilogy is a three-book Norse fantasy series, written under the pen name E. A. Westbo. Book I, Salt and Silence, and Book II, The Long Return, are complete and readable in full at fiction.finnoybu.com. Book III, Drawer of Vows, is drafted.',
     url: 'https://fiction.finnoybu.com',
   },
   {


### PR DESCRIPTION
Book II (*The Long Return*) flipped live on fiction.finnoybu.com on 2026-05-26. The umbrella's trilogy card was still saying "Books II and III are drafted" — updates it to reflect that I + II are complete and III is drafted.

Two-line copy change in `src/data/projects.ts`.

(Reminder: finnoybu-com deploys manually via wrangler, not git-integrated — merging this PR doesn't push to production. Run `npx wrangler pages deploy ./dist --project-name=finnoybu-com --branch=main --commit-dirty=true` from the repo root after merge.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)