### PR TITLE
Forward cf-connecting-ip for Better Auth rate limiting on Workers

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8820,16 +8820,6 @@
       "version": "0.5.8",
       "license": "MIT"
     },
-    "node_modules/yaml-language-server/node_modules/yaml": {
-      "version": "2.7.1",
-      "license": "ISC",
-      "bin": {
-        "yaml": "bin.mjs"
-      },
-      "engines": {
-        "node": ">= 14"
-      }
-    },
     "node_modules/yargs": {
       "version": "17.7.2",
       "license": "MIT",

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -204,9 +204,15 @@ export function createAuth({
         },
       }),
     ],
-    ...(cookieDomain
-      ? {
-          advanced: {
+    advanced: {
+      // Workers doesn't expose a client IP to Better Auth by default, so its
+      // rate limiting silently no-ops ("could not determine client IP").
+      // Cloudflare always forwards the real IP in cf-connecting-ip.
+      ipAddress: {
+        ipAddressHeaders: ['cf-connecting-ip'],
+      },
+      ...(cookieDomain
+        ? {
             defaultCookieAttributes: {
               domain: cookieDomain,
               sameSite: 'lax' as const,
@@ -227,9 +233,9 @@ export function createAuth({
                 },
               },
             },
-          },
-        }
-      : {}),
+          }
+        : {}),
+    },
   });
 }
 


### PR DESCRIPTION
Better Auth logged `WARN: Rate limiting skipped: could not determine client IP address` on Workers — so its built-in rate limiting was silently doing nothing. Cloudflare always forwards the real client IP in `cf-connecting-ip`.

**Change:** set `advanced.ipAddress.ipAddressHeaders = ['cf-connecting-ip']` in `createAuth`. Restructured so `advanced` is always present (carrying the IP config); the existing cookie-domain block (and Apple state-cookie tweak, on finnoybu) stays conditional on `cookieDomain`.

`astro check` 0 errors; build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)